### PR TITLE
Introduce Notes Page with Fullscreen feature

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -11,8 +11,8 @@ export default function About() {
   return (
     <div className="relative min-h-screen w-full bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-gray-900 dark:via-blue-950 dark:to-indigo-950">
       {/* Hero Section */}
-      <section className="relative px-4 pt-16 pb-8 sm:px-6 lg:px-8">
-        <div className="relative z-2 mx-auto max-w-4xl text-center">
+      <section className="relative px-4 pt-10 pb-6 sm:px-6 lg:px-8">
+        <div className="relative z-2 mx-auto max-w-6xl text-center">
           <div className="mb-4 inline-flex items-center rounded-full bg-blue-100 px-4 py-2 text-sm font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-200">
             <SparklesIcon className="mr-2 h-4 w-4" />
             Get to know me
@@ -24,8 +24,8 @@ export default function About() {
         </div>
 
         {/* Floating Elements */}
-        <div className="absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2 opacity-25">
-          <div className="h-72 w-72 rounded-full bg-gradient-to-r from-blue-400 to-indigo-400 blur-3xl sm:h-96 sm:w-96"></div>
+        <div className="absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2 opacity-30">
+          <div className="h-60 w-60 rounded-full bg-gradient-to-r from-blue-400 to-indigo-400 blur-3xl sm:h-72 sm:w-72"></div>
         </div>
       </section>
 

--- a/src/app/comments/page.tsx
+++ b/src/app/comments/page.tsx
@@ -13,8 +13,8 @@ export default function CommentsPage() {
   return (
     <div className="relative min-h-screen w-full bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-gray-900 dark:via-blue-950 dark:to-indigo-950">
       {/* Hero Section */}
-      <section className="relative px-4 pt-16 pb-8 sm:px-6 lg:px-8">
-        <div className="relative z-2 mx-auto max-w-4xl text-center">
+      <section className="relative px-4 pt-10 pb-6 sm:px-6 lg:px-8">
+        <div className="relative z-2 mx-auto max-w-6xl text-center">
           <div className="mb-4 inline-flex items-center rounded-full bg-blue-100 px-4 py-2 text-sm font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-200">
             <HeartIcon className="mr-2 h-4 w-4" />
             Guest Comments
@@ -24,14 +24,14 @@ export default function CommentsPage() {
             Leave a Comment
           </h1>
 
-          <p className="mx-auto mb-6 max-w-2xl text-lg leading-7 text-gray-600 sm:text-xl sm:leading-8 dark:text-gray-300">
+          <p className="mx-auto mb-6 max-w-4xl text-lg leading-7 text-gray-600 sm:text-xl sm:leading-8 dark:text-gray-300">
             {`Share your thoughts, feedback, or just say hello! I'd love to hear from you.`}
           </p>
         </div>
 
         {/* Floating Elements */}
-        <div className="absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2 opacity-25">
-          <div className="h-72 w-72 rounded-full bg-gradient-to-r from-blue-400 to-indigo-400 blur-3xl sm:h-96 sm:w-96"></div>
+        <div className="absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2 opacity-30">
+          <div className="h-60 w-60 rounded-full bg-gradient-to-r from-blue-400 to-indigo-400 blur-3xl sm:h-72 sm:w-72"></div>
         </div>
       </section>
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -18,8 +18,8 @@ export default function Contact() {
   return (
     <div className="relative min-h-screen w-full bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-gray-900 dark:via-blue-950 dark:to-indigo-950">
       {/* Hero Section */}
-      <section className="relative px-4 pt-16 pb-8 sm:px-6 lg:px-8">
-        <div className="relative z-2 mx-auto max-w-4xl text-center">
+      <section className="relative px-4 pt-10 pb-6 sm:px-6 lg:px-8">
+        <div className="relative z-2 mx-auto max-w-6xl text-center">
           <div className="mb-4 inline-flex items-center rounded-full bg-blue-100 px-4 py-2 text-sm font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-200">
             <SparklesIcon className="mr-2 h-4 w-4" />
             {`Let's connect`}
@@ -29,14 +29,14 @@ export default function Contact() {
             Contact Me
           </h1>
 
-          <p className="mx-auto mb-6 max-w-2xl text-lg leading-7 text-gray-600 sm:text-xl sm:leading-8 dark:text-gray-300">
+          <p className="mx-auto mb-6 max-w-4xl text-lg leading-7 text-gray-600 sm:text-xl sm:leading-8 dark:text-gray-300">
             {`Ready to bring your ideas to life? Let's discuss how we can work together to create something amazing.`}
           </p>
         </div>
 
         {/* Floating Elements */}
-        <div className="absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2 opacity-25">
-          <div className="h-72 w-72 rounded-full bg-gradient-to-r from-blue-400 to-indigo-400 blur-3xl sm:h-96 sm:w-96"></div>
+        <div className="absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2 opacity-30">
+          <div className="h-60 w-60 rounded-full bg-gradient-to-r from-blue-400 to-indigo-400 blur-3xl sm:h-72 sm:w-72"></div>
         </div>
       </section>
 

--- a/src/app/notes/components/NotionContainer.tsx
+++ b/src/app/notes/components/NotionContainer.tsx
@@ -1,42 +1,102 @@
-import { DocumentTextIcon, ArrowLeftIcon } from "@heroicons/react/24/outline";
+"use client";
+
+import {
+  DocumentTextIcon,
+  ArrowLeftIcon,
+  ArrowsPointingOutIcon,
+  ArrowsPointingInIcon,
+} from "@heroicons/react/24/outline";
 import Link from "next/link";
+import { motion } from "motion/react";
+import { useState, useEffect } from "react";
 
 export default function NotionContainer() {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && isFullscreen) {
+        setIsFullscreen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isFullscreen]);
+
+  useEffect(() => {
+    if (isFullscreen) {
+      document.body.classList.add("overflow-hidden");
+    } else {
+      document.body.classList.remove("overflow-hidden");
+    }
+
+    return () => {
+      document.body.classList.remove("overflow-hidden");
+    };
+  }, [isFullscreen]);
+
+  const toggleFullscreen = () => {
+    setIsFullscreen(!isFullscreen);
+  };
+
   return (
-    <div className="overflow-hidden rounded-2xl bg-white/80 shadow-2xl backdrop-blur-sm dark:bg-gray-800/80">
+    <motion.div
+      layout
+      className={`flex flex-col overflow-hidden bg-white/80 shadow-2xl backdrop-blur-sm dark:bg-gray-800/80 ${
+        isFullscreen ? "fixed inset-0 z-50 rounded-none" : "h-[calc(100dvh-(--spacing(16))-(--spacing(4)))] rounded-2xl"
+      } `}
+      transition={{ layout: { duration: 0.3, ease: "easeInOut" } }}
+    >
       {/* Container Header */}
-      <div className="border-b border-gray-200 bg-gradient-to-r from-orange-50 to-red-50 px-4 py-3 md:px-6 md:py-4 dark:border-gray-700 dark:from-orange-900/20 dark:to-red-900/20">
+      <div className="flex-shrink-0 border-b border-gray-200 bg-gradient-to-r from-orange-50 to-red-50 px-4 py-3 md:px-6 md:py-4 dark:border-gray-700 dark:from-orange-900/20 dark:to-red-900/20">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <div className="flex items-center gap-3">
             <DocumentTextIcon className="h-6 w-6 text-orange-600 dark:text-orange-400" />
             <div>
               <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Frontend Development Notes</h2>
+              {isFullscreen && (
+                <p className="mt-0.5 text-xs text-gray-600 dark:text-gray-400">Press ESC to exit fullscreen</p>
+              )}
             </div>
           </div>
-          <Link
-            href="https://merrickcai.notion.site/frontend-development"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center rounded-lg bg-orange-100 px-3 py-2 text-sm font-medium text-orange-800 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-200 dark:hover:bg-orange-900/50"
-          >
-            Open in Notion
-            <ArrowLeftIcon className="ml-1 h-3 w-3 rotate-45" />
-          </Link>
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={toggleFullscreen}
+              className="inline-flex cursor-pointer items-center rounded-lg bg-blue-100 px-3 py-2 text-sm font-medium text-blue-800 transition-colors duration-200 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-200 dark:hover:bg-blue-900/50"
+              title={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+            >
+              {isFullscreen ? (
+                <ArrowsPointingInIcon className="mr-1 h-4 w-4" />
+              ) : (
+                <ArrowsPointingOutIcon className="mr-1 h-4 w-4" />
+              )}
+              {isFullscreen ? "Exit Fullscreen" : "Fullscreen"}
+            </button>
+
+            <Link
+              href="https://merrickcai.notion.site/frontend-development"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center rounded-lg bg-orange-100 px-3 py-2 text-sm font-medium text-orange-800 transition-colors duration-200 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-200 dark:hover:bg-orange-900/50"
+            >
+              Open in Notion
+              <ArrowLeftIcon className="ml-1 h-3 w-3 rotate-45" />
+            </Link>
+          </div>
         </div>
       </div>
 
       {/* Notion Iframe */}
-      <div className="relative">
+      <div className="relative flex-grow">
         <iframe
           src="https://merrickcai.notion.site/ebd/188e3a07cc988036a524c65fb43d2d06"
-          width="100%"
-          height="600"
-          frameBorder="0"
           allowFullScreen
-          className="w-full"
+          className="h-full w-full border-none"
           title="Merrick's Development Notes"
         />
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/src/app/notes/components/NotionContainer.tsx
+++ b/src/app/notes/components/NotionContainer.tsx
@@ -1,0 +1,42 @@
+import { DocumentTextIcon, ArrowLeftIcon } from "@heroicons/react/24/outline";
+import Link from "next/link";
+
+export default function NotionContainer() {
+  return (
+    <div className="overflow-hidden rounded-2xl bg-white/80 shadow-2xl backdrop-blur-sm dark:bg-gray-800/80">
+      {/* Container Header */}
+      <div className="border-b border-gray-200 bg-gradient-to-r from-orange-50 to-red-50 px-4 py-3 md:px-6 md:py-4 dark:border-gray-700 dark:from-orange-900/20 dark:to-red-900/20">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex items-center gap-3">
+            <DocumentTextIcon className="h-6 w-6 text-orange-600 dark:text-orange-400" />
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Frontend Development Notes</h2>
+            </div>
+          </div>
+          <Link
+            href="https://merrickcai.notion.site/frontend-development"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center rounded-lg bg-orange-100 px-3 py-2 text-sm font-medium text-orange-800 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-200 dark:hover:bg-orange-900/50"
+          >
+            Open in Notion
+            <ArrowLeftIcon className="ml-1 h-3 w-3 rotate-45" />
+          </Link>
+        </div>
+      </div>
+
+      {/* Notion Iframe */}
+      <div className="relative">
+        <iframe
+          src="https://merrickcai.notion.site/ebd/188e3a07cc988036a524c65fb43d2d06"
+          width="100%"
+          height="600"
+          frameBorder="0"
+          allowFullScreen
+          className="w-full"
+          title="Merrick's Development Notes"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
-import { DocumentTextIcon, ArrowLeftIcon } from "@heroicons/react/24/outline";
-import Link from "next/link";
+import { DocumentTextIcon } from "@heroicons/react/24/outline";
+import NotionContainer from "@/app/notes/components/NotionContainer";
 
 export const metadata: Metadata = {
   title: "Development Notes | MerrickCai.dev",
@@ -35,45 +35,11 @@ export default function Notes() {
         </div>
       </section>
 
-      {/* Notion Embed Section */}
+      {/* Notion Section */}
       <section className="relative px-4 pb-12 sm:px-6 sm:pb-16 lg:px-8">
         <div className="mx-auto max-w-7xl">
-          {/* Embed Container */}
-          <div className="overflow-hidden rounded-2xl bg-white/80 shadow-2xl backdrop-blur-sm dark:bg-gray-800/80">
-            {/* Embed Header */}
-            <div className="border-b border-gray-200 bg-gradient-to-r from-orange-50 to-red-50 px-4 py-3 md:px-6 md:py-4 dark:border-gray-700 dark:from-orange-900/20 dark:to-red-900/20">
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <div className="flex items-center gap-3">
-                  <DocumentTextIcon className="h-6 w-6 text-orange-600 dark:text-orange-400" />
-                  <div>
-                    <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Frontend Development Notes</h2>
-                  </div>
-                </div>
-                <Link
-                  href="https://merrickcai.notion.site/frontend-development"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center rounded-lg bg-orange-100 px-3 py-2 text-sm font-medium text-orange-800 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-200 dark:hover:bg-orange-900/50"
-                >
-                  Open in Notion
-                  <ArrowLeftIcon className="ml-1 h-3 w-3 rotate-45" />
-                </Link>
-              </div>
-            </div>
-
-            {/* Notion Iframe */}
-            <div className="relative">
-              <iframe
-                src="https://merrickcai.notion.site/ebd/188e3a07cc988036a524c65fb43d2d06"
-                width="100%"
-                height="600"
-                frameBorder="0"
-                allowFullScreen
-                className="w-full"
-                title="Merrick's Development Notes"
-              />
-            </div>
-          </div>
+          {/* Notion Container */}
+          <NotionContainer />
 
           {/* Additional Info */}
           <div className="mt-8 text-center">

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+import { DocumentTextIcon, ArrowLeftIcon } from "@heroicons/react/24/outline";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Development Notes | MerrickCai.dev",
+  description:
+    "Detailed documentation of my learning journey, best practices, and insights from frontend development projects",
+};
+
+export default function Notes() {
+  return (
+    <div className="relative min-h-screen w-full bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-gray-900 dark:via-blue-950 dark:to-indigo-950">
+      {/* Header Section */}
+      <section className="relative px-4 pt-16 pb-8 sm:px-6 lg:px-8">
+        <div className="relative z-2 mx-auto max-w-4xl text-center">
+          <div className="mb-4 inline-flex items-center rounded-full bg-orange-100 px-4 py-2 text-sm font-medium text-orange-800 dark:bg-orange-900/30 dark:text-orange-200">
+            <DocumentTextIcon className="mr-2 h-4 w-4" />
+            Development Documentation
+          </div>
+
+          <h1 className="mb-4 bg-gradient-to-r from-gray-900 via-orange-900 to-red-900 bg-clip-text text-4xl font-bold tracking-tight text-transparent sm:text-5xl md:text-6xl dark:from-white dark:via-orange-100 dark:to-red-100">
+            Development Notes
+          </h1>
+
+          <p className="mx-auto mb-6 max-w-2xl text-lg leading-7 text-gray-600 sm:text-xl sm:leading-8 dark:text-gray-300">
+            Explore my comprehensive documentation of frontend development concepts, best practices, and project
+            insights.
+          </p>
+        </div>
+
+        {/* Floating Elements */}
+        <div className="absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2 opacity-25">
+          <div className="h-72 w-72 rounded-full bg-gradient-to-r from-orange-400 to-red-400 blur-3xl sm:h-96 sm:w-96"></div>
+        </div>
+      </section>
+
+      {/* Notion Embed Section */}
+      <section className="relative px-4 pb-12 sm:px-6 sm:pb-16 lg:px-8">
+        <div className="mx-auto max-w-7xl">
+          <div className="overflow-hidden rounded-2xl bg-white/80 shadow-2xl backdrop-blur-sm dark:bg-gray-800/80">
+            {/* Embed Header */}
+            <div className="border-b border-gray-200 bg-gradient-to-r from-orange-50 to-red-50 px-6 py-4 dark:border-gray-700 dark:from-orange-900/20 dark:to-red-900/20">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center">
+                  <DocumentTextIcon className="mr-3 h-6 w-6 text-orange-600 dark:text-orange-400" />
+                  <div>
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                      Frontend Development Documentation
+                    </h2>
+                    <p className="text-sm text-gray-600 dark:text-gray-300">Comprehensive notes and best practices</p>
+                  </div>
+                </div>
+                <Link
+                  href="https://merrickcai.notion.site/frontend-development"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center rounded-lg bg-orange-100 px-3 py-2 text-sm font-medium text-orange-800 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-200 dark:hover:bg-orange-900/50"
+                >
+                  Open in Notion
+                  <ArrowLeftIcon className="ml-1 h-3 w-3 rotate-45" />
+                </Link>
+              </div>
+            </div>
+
+            {/* Notion Iframe */}
+            <div className="relative">
+              <iframe
+                src="https://merrickcai.notion.site/ebd/188e3a07cc988036a524c65fb43d2d06"
+                width="100%"
+                height="600"
+                frameBorder="0"
+                allowFullScreen
+                className="w-full"
+                title="Merrick's Development Notes"
+              />
+            </div>
+          </div>
+
+          {/* Additional Info */}
+          <div className="mt-8 text-center">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              📝 This documentation is continuously updated with new insights and learnings from my development journey.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -38,17 +38,15 @@ export default function Notes() {
       {/* Notion Embed Section */}
       <section className="relative px-4 pb-12 sm:px-6 sm:pb-16 lg:px-8">
         <div className="mx-auto max-w-7xl">
+          {/* Embed Container */}
           <div className="overflow-hidden rounded-2xl bg-white/80 shadow-2xl backdrop-blur-sm dark:bg-gray-800/80">
             {/* Embed Header */}
-            <div className="border-b border-gray-200 bg-gradient-to-r from-orange-50 to-red-50 px-6 py-4 dark:border-gray-700 dark:from-orange-900/20 dark:to-red-900/20">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center">
-                  <DocumentTextIcon className="mr-3 h-6 w-6 text-orange-600 dark:text-orange-400" />
+            <div className="border-b border-gray-200 bg-gradient-to-r from-orange-50 to-red-50 px-4 py-3 md:px-6 md:py-4 dark:border-gray-700 dark:from-orange-900/20 dark:to-red-900/20">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex items-center gap-3">
+                  <DocumentTextIcon className="h-6 w-6 text-orange-600 dark:text-orange-400" />
                   <div>
-                    <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-                      Frontend Development Documentation
-                    </h2>
-                    <p className="text-sm text-gray-600 dark:text-gray-300">Comprehensive notes and best practices</p>
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Frontend Development Notes</h2>
                   </div>
                 </div>
                 <Link

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -12,8 +12,8 @@ export default function Notes() {
   return (
     <div className="relative min-h-screen w-full bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-gray-900 dark:via-blue-950 dark:to-indigo-950">
       {/* Header Section */}
-      <section className="relative px-4 pt-16 pb-8 sm:px-6 lg:px-8">
-        <div className="relative z-2 mx-auto max-w-4xl text-center">
+      <section className="relative px-4 pt-10 pb-6 sm:px-6 lg:px-8">
+        <div className="relative z-2 mx-auto max-w-6xl text-center">
           <div className="mb-4 inline-flex items-center rounded-full bg-orange-100 px-4 py-2 text-sm font-medium text-orange-800 dark:bg-orange-900/30 dark:text-orange-200">
             <DocumentTextIcon className="mr-2 h-4 w-4" />
             Development Documentation
@@ -23,15 +23,15 @@ export default function Notes() {
             Development Notes
           </h1>
 
-          <p className="mx-auto mb-6 max-w-2xl text-lg leading-7 text-gray-600 sm:text-xl sm:leading-8 dark:text-gray-300">
+          <p className="mx-auto mb-6 max-w-4xl text-lg leading-7 text-gray-600 sm:text-xl sm:leading-8 dark:text-gray-300">
             Explore my comprehensive documentation of frontend development concepts, best practices, and project
             insights.
           </p>
         </div>
 
         {/* Floating Elements */}
-        <div className="absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2 opacity-25">
-          <div className="h-72 w-72 rounded-full bg-gradient-to-r from-orange-400 to-red-400 blur-3xl sm:h-96 sm:w-96"></div>
+        <div className="absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2 opacity-30">
+          <div className="h-60 w-60 rounded-full bg-gradient-to-r from-orange-400 to-red-400 blur-3xl sm:h-72 sm:w-72"></div>
         </div>
       </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import FloatingParticles from "@/components/ui/FloatingParticles";
 
 import {
   ArrowRightIcon,
+  ArrowTopRightOnSquareIcon,
   CodeBracketIcon,
   UserIcon,
   RocketLaunchIcon,
@@ -209,15 +210,24 @@ export default function Home() {
                     Detailed documentation of my learning journey, best practices, and insights from frontend
                     development projects.
                   </p>
-                  <Link
-                    href="https://merrickcai.notion.site/Frontend-Development-188e3a07cc988036a524c65fb43d2d06"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center text-sm font-medium text-orange-600 hover:text-orange-700 sm:text-base dark:text-orange-400 dark:hover:text-orange-300"
-                  >
-                    View on Notion
-                    <ArrowRightIcon className="ml-1 h-3 w-3 sm:h-4 sm:w-4" />
-                  </Link>
+                  <div className="flex flex-wrap gap-5">
+                    <Link
+                      href="/notes"
+                      className="inline-flex items-center text-sm font-medium text-orange-600 hover:text-orange-700 sm:text-base dark:text-orange-400 dark:hover:text-orange-300"
+                    >
+                      View Here
+                      <ArrowRightIcon className="ml-1 h-3 w-3 sm:h-4 sm:w-4" />
+                    </Link>
+                    <Link
+                      href="https://merrickcai.notion.site/frontend-development"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center text-sm font-medium text-orange-600 hover:text-orange-700 sm:text-base dark:text-orange-400 dark:hover:text-orange-300"
+                    >
+                      View on Notion
+                      <ArrowTopRightOnSquareIcon className="ml-1 h-3 w-3 sm:h-4 sm:w-4" />
+                    </Link>
+                  </div>
                 </div>
               </div>
             </RevealOnScroll>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,9 +29,9 @@ export default function Home() {
       <FloatingParticles count={30} />
 
       {/* Hero Section */}
-      <section className="relative px-4 pt-16 pb-8 sm:px-6 lg:px-8">
+      <section className="relative px-4 pt-10 pb-6 sm:px-6 lg:px-8">
         <RevealOnScroll>
-          <div className="relative z-2 mx-auto max-w-4xl text-center">
+          <div className="relative z-2 mx-auto max-w-6xl text-center">
             <div className="mb-4 inline-flex items-center rounded-full bg-blue-100 px-4 py-2 text-sm font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-200">
               <SparklesIcon className="mr-2 h-4 w-4" />
               Welcome to my digital space
@@ -57,7 +57,7 @@ export default function Home() {
               />
             </div>
 
-            <p className="mx-auto mb-6 max-w-2xl text-lg leading-7 text-gray-600 sm:text-xl sm:leading-8 dark:text-gray-300">
+            <p className="mx-auto mb-6 max-w-4xl text-lg leading-7 text-gray-600 sm:text-xl sm:leading-8 dark:text-gray-300">
               Crafting exceptional digital experiences with React, Next.js, and modern web technologies. Building the
               future, one component at a time.
             </p>
@@ -82,8 +82,8 @@ export default function Home() {
           </div>
 
           {/* Floating Elements */}
-          <div className="absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2 opacity-25">
-            <div className="h-72 w-72 rounded-full bg-gradient-to-r from-blue-400 to-indigo-400 blur-3xl sm:h-96 sm:w-96"></div>
+          <div className="absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2 opacity-30">
+            <div className="h-60 w-60 rounded-full bg-gradient-to-r from-blue-400 to-indigo-400 blur-3xl sm:h-72 sm:w-72"></div>
           </div>
         </RevealOnScroll>
       </section>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -47,8 +47,8 @@ export default function Projects() {
   return (
     <div className="relative min-h-screen w-full bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-gray-900 dark:via-blue-950 dark:to-indigo-950">
       {/* Hero Section */}
-      <section className="relative px-4 pt-16 pb-8 sm:px-6 lg:px-8">
-        <div className="relative z-2 mx-auto max-w-4xl text-center">
+      <section className="relative px-4 pt-10 pb-6 sm:px-6 lg:px-8">
+        <div className="relative z-2 mx-auto max-w-6xl text-center">
           <div className="mb-4 inline-flex items-center rounded-full bg-blue-100 px-4 py-2 text-sm font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-200">
             <SparklesIcon className="mr-2 h-4 w-4" />
             Portfolio showcase
@@ -58,14 +58,14 @@ export default function Projects() {
             My Projects
           </h1>
 
-          <p className="mx-auto mb-6 max-w-2xl text-lg leading-7 text-gray-600 sm:text-xl sm:leading-8 dark:text-gray-300">
+          <p className="mx-auto mb-6 max-w-4xl text-lg leading-7 text-gray-600 sm:text-xl sm:leading-8 dark:text-gray-300">
             Showcasing my skills in frontend development, full-stack applications, and modern web technologies.
           </p>
         </div>
 
         {/* Floating Elements */}
-        <div className="absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2 opacity-25">
-          <div className="h-72 w-72 rounded-full bg-gradient-to-r from-blue-400 to-indigo-400 blur-3xl sm:h-96 sm:w-96"></div>
+        <div className="absolute top-1/2 left-1/2 z-1 -translate-x-1/2 -translate-y-1/2 opacity-30">
+          <div className="h-60 w-60 rounded-full bg-gradient-to-r from-blue-400 to-indigo-400 blur-3xl sm:h-72 sm:w-72"></div>
         </div>
       </section>
 


### PR DESCRIPTION
This pull request introduces a new `/notes` page to showcase development documentation, featuring a custom interactive Notion embed component. It also updates the homepage to direct users to this new page, while still providing an external Notion link. The changes improve the user experience by offering a dedicated, styled section for notes and a more intuitive navigation flow.

**New Notes Page and Notion Integration:**

* Added a new `NotionContainer` component with fullscreen support, keyboard handling, and custom styling for embedding Notion documentation (`src/app/notes/components/NotionContainer.tsx`).
* Implemented the `/notes` page, including a header, introduction, floating background elements, and the `NotionContainer` embed, along with a note about ongoing updates (`src/app/notes/page.tsx`).

**Homepage Navigation and UI Updates:**

* Updated the homepage to add a "View Here" link to the new `/notes` page, and changed the external Notion link to use a new icon for clarity (`src/app/page.tsx`).
* Imported the `ArrowTopRightOnSquareIcon` for improved external link indication on the homepage (`src/app/page.tsx`).